### PR TITLE
Add shortcuts and other fixes, start changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ until we achieve a stable v1.0 release
   rather than 'toggle full-screen' (now `command-shift-f`)
 - 🚀 NEW: Support for blank-screen shortcuts
   (inspired by [Curtis Wilcox](https://codepen.io/ccwilcox/details/NWJWwOE))
+- 🚀 NEW: Both start/resume events target active slides
 - 🚀 NEW: Control panel includes toggle for keyboard controls
 - 🚀 NEW: Control panel buttons have `aria-pressed` styles
 - 🚀 NEW: All slide-event buttons that toggle a boolean state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changes
+
+**⚠️ This is a pre-release**:
+Breaking changes will be allowed in minor versions
+until we achieve a stable v1.0 release
+
+## v0.1.1 - unreleased
+
+- 💥 BREAKING: Updated keyboard shortcuts
+  to match [PowerPoint](https://support.microsoft.com/en-us/office/use-keyboard-shortcuts-to-deliver-powerpoint-presentations-1524ffce-bd2a-45f4-9a7f-f18b992b93a0#bkmk_frequent_macos),
+  including `command-.` as 'end presentation'
+  rather than 'toggle full-screen' (now `command-shift-f`)
+- 🚀 NEW: Support for blank-screen shortcuts
+  (inspired by [Curtis Wilcox](https://codepen.io/ccwilcox/details/NWJWwOE))
+- 🚀 NEW: Control panel includes toggle for keyboard controls
+- 🚀 NEW: Control panel buttons have `aria-pressed` styles
+- 🚀 NEW: All slide-event buttons that toggle a boolean state
+  get `aria-pressed` values that update with the state
+- 🐞 FIXED: Scroll to the active slide when changing views
+- 🐞 FIXED: Control panel view toggles were broken
+- 🐞 FIXED: Control panel prevents propagation of keyboard shortcuts
+- 👀 INTERNAL: The current slide is stored in an `activeSlide` property
+
+## v0.1.0 - 2023-12-22
+
+Initial draft
+based on
+[Miriam's Proof of Concept](https://codepen.io/miriamsuzanne/pen/eYXOLjE?editors=1010).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A Web Component for web presentations.
 
 **[Demo](https://slide-deck.netlify.app)**
 
+**⚠️ This is a pre-release**:
+Breaking changes will be allowed in minor versions
+until we achieve a stable v1.0 release
+
 ## Examples
 
 General usage example:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,29 @@ This Web Component allows you to:
 - Follow along in a second tab (speaker view)
 - Toggle full-screen mode
 
+## Keyboard Shortcuts
+
+Always available:
+
+- `command-k`: Toggle control panel
+- `command-shift-enter`: Start presentation (from first slide)
+- `command-enter`: Resume presentation (from active slide)
+- `command-shift-f`: Toggle full-screen mode
+
+When presenting (key-control is active):
+
+- `N`/`rightArrow`/`downArrow`/`pageDown`: Next slide
+- `P`/`leftArrow`/`upArrow`/`pageUp`: Previous slide
+- `home`: First slide
+- `end`: Last slide
+- `W`/`,`: Toggle white screen
+- `B`/`.`: Toggle black screen
+- `escape`: Blur focused element, close control panel, or end presentation
+- `command-.`: End presentation
+
+These are based on
+the [PowerPoint shortcuts](https://support.microsoft.com/en-us/office/use-keyboard-shortcuts-to-deliver-powerpoint-presentations-1524ffce-bd2a-45f4-9a7f-f18b992b93a0#bkmk_frequent_macos).
+
 ## Installation
 
 You have a few options (choose one of these):

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Always available:
 - `command-k`: Toggle control panel
 - `command-shift-enter`: Start presentation (from first slide)
 - `command-enter`: Resume presentation (from active slide)
+- `command-.`: End presentation
 - `command-shift-f`: Toggle full-screen mode
 
 When presenting (key-control is active):
@@ -85,7 +86,6 @@ When presenting (key-control is active):
 - `W`/`,`: Toggle white screen
 - `B`/`.`: Toggle black screen
 - `escape`: Blur focused element, close control panel, or end presentation
-- `command-.`: End presentation
 
 These are based on
 the [PowerPoint shortcuts](https://support.microsoft.com/en-us/office/use-keyboard-shortcuts-to-deliver-powerpoint-presentations-1524ffce-bd2a-45f4-9a7f-f18b992b93a0#bkmk_frequent_macos).

--- a/index.html
+++ b/index.html
@@ -10,7 +10,12 @@
   </head>
   <body>
     <slide-deck id="my-slides" key-control>
-      <header><h1>Slide-Deck Web Component</h1></header>
+      <header>
+        <h1>Slide-Deck Web Component</h1>
+        <p>
+          <a href="https://github.com/oddbird/slide-deck/">github.com/oddbird/slide-deck/</a>
+        </p>
+      </header>
       <div><h2>No Dependencies</h2></div>
       <div><h2>Progressive Enhancement</h2></div>
       <div><h2>Just HTML</h2></div>
@@ -18,20 +23,54 @@
       <div>
         <h3>Always available:</h3>
         <ul>
-          <li><strong>command-k</strong>: control panel</li>
-          <li><strong>command-period</strong>: fullscreen</li>
+          <li><strong>command-k</strong>: Toggle control panel</li>
+          <li><strong>command-shift-enter</strong>: Start presentation (from first slide)</li>
+          <li><strong>command-enter</strong>: Resume presentation (from active slide)</li>
+          <li><strong>command-shift-f</strong>: Toggle full-screen mode</li>
         </ul>
       </div>
       <div>
         <h3>Active Presentation:</h3>
         <ul>
           <li>
-            <strong>right-arrow</strong>/<strong>page-down</strong>:
-            next slide
+            <strong>N</strong>
+            / <strong>right-arrow</strong>
+            / <strong>down-arrow</strong>
+            / <strong>page-down</strong>:
+            Next slide
           </li>
           <li>
-            <strong>left-arrow</strong>/<strong>page-up</strong>:
-            previous slide
+            <strong>P</strong>
+            / <strong>left-arrow</strong>
+            / <strong>up-arrow</strong>
+            / <strong>page-up</strong>:
+            Previous slide
+          </li>
+          <li>
+            <strong>home</strong>:
+            First slide
+          </li>
+          <li>
+            <strong>end</strong>:
+            Last slide
+          </li>
+          <li>
+            <strong>W</strong>
+            / <strong>,</strong>:
+            Toggle white screen
+          </li>
+          <li>
+            <strong>B</strong>
+            / <strong>.</strong>:
+            Toggle black screen
+          </li>
+          <li>
+            <strong>escape</strong>:
+            Blur focused element, close control panel, or end presentation
+          </li>
+          <li>
+            <strong>command-.</strong>:
+            End presentation
           </li>
         </ul>
       </div>
@@ -53,18 +92,17 @@
         </div>
       </div>
       <div><h2>Speaker View</h2></div>
-      <div><h2>Open Source</h2></div>
       <div>
-        <h3>ToDo: Github Repo</h3>
-        <p>(and NPM package??)</p>
+        <h2>Open Source</h2>
+        <p>
+          <a href="https://github.com/oddbird/slide-deck/">github.com/oddbird/slide-deck/</a>
+        </p>
       </div>
-      <div><h3>ToDo: Full Documentation</h3></div>
-      <div><h3>ToDo: Improved</h3></div>
-      <div><h3>ToDo: Speaker Notes</h3></div>
-      <div><h3>ToDo: Slide Templates</h3></div>
-      <div><h3>ToDo: CSS Themes</h3></div>
-      <div><h3>ToDo: More Shortcuts</h3></div>
-      <div><h3>ToDo: More Better Good Stuff</h3></div>
+      <div><h2>To Do…</h2></div>
+      <div><h3>… Speaker Notes</h3></div>
+      <div><h3>… Slide Templates</h3></div>
+      <div><h3>… CSS Themes</h3></div>
+      <div><h3>… More Better Good Stuff</h3></div>
     </slide-deck>
 
   </body>

--- a/index.html
+++ b/index.html
@@ -27,6 +27,10 @@
           <li><strong>command-shift-enter</strong>: Start presentation (from first slide)</li>
           <li><strong>command-enter</strong>: Resume presentation (from active slide)</li>
           <li><strong>command-shift-f</strong>: Toggle full-screen mode</li>
+          <li>
+            <strong>command-.</strong>:
+            End presentation
+          </li>
         </ul>
       </div>
       <div>
@@ -67,10 +71,6 @@
           <li>
             <strong>escape</strong>:
             Blur focused element, close control panel, or end presentation
-          </li>
-          <li>
-            <strong>command-.</strong>:
-            End presentation
           </li>
         </ul>
       </div>

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -188,9 +188,6 @@ class slideDeck extends HTMLElement {
     this[slideDeck.attrToPropMap[name]] = newValue || this.hasAttribute(name);
 
     switch (name) {
-      case 'full-screen':
-        this.fullScreenChange();
-        break;
       case 'follow-active':
         this.followActiveChange();
         break;
@@ -240,7 +237,7 @@ class slideDeck extends HTMLElement {
     // custom events
     this.addEventListener('toggleControl', (e) => this.toggleAttribute('key-control'));
     this.addEventListener('toggleFollow', (e) => this.toggleAttribute('follow-active'));
-    this.addEventListener('toggleFullscreen', (e) => this.toggleAttribute('full-screen'));
+    this.addEventListener('toggleFullscreen', (e) => this.fullScreenEvent());
     this.addEventListener('toggleView', (e) => this.toggleView());
     this.addEventListener('grid', (e) => this.toggleView('grid'));
     this.addEventListener('list', (e) => this.toggleView('list'));
@@ -251,6 +248,7 @@ class slideDeck extends HTMLElement {
     this.addEventListener('resume', (e) => this.resumeEvent());
     this.addEventListener('end', (e) => this.endEvent());
     this.addEventListener('reset', (e) => this.resetEvent());
+    this.addEventListener('blankSlide', (e) => this.blankSlideEvent());
 
     this.addEventListener('nextSlide', (e) => this.move(1));
     this.addEventListener('savedSlide', (e) => this.goToSaved());
@@ -411,11 +409,21 @@ class slideDeck extends HTMLElement {
     this.resetActive();
   }
 
-  toggleBlank = (color) => {
+  blankSlideEvent = (color) => {
     if (this.hasAttribute('blank-slide')) {
       this.removeAttribute('blank-slide');
     } else {
       this.setAttribute('blank-slide', color || 'black');
+    }
+  }
+
+  fullScreenEvent = () => {
+    this.toggleAttribute('full-screen');
+
+    if (this.fullScreen && this.requestFullscreen) {
+      this.requestFullscreen();
+    } else if (document.fullscreenElement) {
+      document.exitFullscreen();
     }
   }
 
@@ -426,14 +434,6 @@ class slideDeck extends HTMLElement {
       window.addEventListener('storage', (e) => this.goToSaved());
     } else {
       window.removeEventListener('storage', (e) => this.goToSaved());
-    }
-  }
-
-  fullScreenChange = () => {
-    if (this.fullScreen && this.requestFullscreen) {
-      this.requestFullscreen();
-    } else if (document.fullscreenElement) {
-      document.exitFullscreen();
     }
   }
 
@@ -512,7 +512,7 @@ class slideDeck extends HTMLElement {
         case 'f':
           if (event.shiftKey) {
             event.preventDefault();
-            this.toggleAttribute('full-screen');
+            this.fullScreenEvent();
           }
           break;
         case 'Enter':
@@ -569,11 +569,11 @@ class slideDeck extends HTMLElement {
           break;
         case 'blackOut':
           event.preventDefault();
-          this.toggleBlank('black');
+          this.blankSlideEvent('black');
           break;
         case 'whiteOut':
           event.preventDefault();
-          this.toggleBlank('white');
+          this.blankSlideEvent('white');
           break;
         case 'endPresentation':
           event.preventDefault();

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -524,6 +524,10 @@ class slideDeck extends HTMLElement {
             this.resumeEvent();
           }
           break;
+        case '.':
+          event.preventDefault();
+          this.endEvent();
+          break;
         default:
           break;
       }
@@ -543,12 +547,6 @@ class slideDeck extends HTMLElement {
           event.preventDefault();
           this.endEvent();
         }
-        return;
-      }
-
-      if (event.metaKey && event.key === '.') {
-        event.preventDefault();
-        this.endEvent();
         return;
       }
 

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -228,11 +228,11 @@ class slideDeck extends HTMLElement {
     this.setupViewButtons();
 
     // event listeners
-    this.shadowRoot.addEventListener('keydown', (e) => {
-      e.stopPropagation();
+    this.shadowRoot.addEventListener('keydown', (event) => {
+      event.stopPropagation();
 
-      if (e.key === 'k' && e.metaKey) {
-        e.preventDefault();
+      if ((event.key === 'k' && event.metaKey) || event.key === 'Escape') {
+        event.preventDefault();
         this.controlPanel.close();
       }
     });

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -7,14 +7,16 @@ class slideDeck extends HTMLElement {
         <form method="dialog"><button>close</button></form>
         <div>
           <slot name="slide-controls">
+            <button slide-event='toggleControl'>keyboard controls</button>
+
             <p><strong>Presentation:</strong></p>
             <button slide-event>start</button>
             <button slide-event>end</button>
             <button slide-event="joinWithNotes">speaker view</button>
 
             <p><strong>View:</strong></p>
-            <button slide-view>grid</button>
-            <button slide-view>list</button>
+            <button set-view>grid</button>
+            <button set-view>list</button>
           </slot>
         </div>
       </dialog>
@@ -30,12 +32,15 @@ class slideDeck extends HTMLElement {
   static adoptShadowStyles = (node) => {
     const shadowStyle = new CSSStyleSheet();
     shadowStyle.replaceSync(`
+      :host {
+        position: relative;
+      }
+
       :host:not(:fullscreen) {
         container: host / inline-size;
       }
 
       :host(:fullscreen) {
-        container-type: auto;
         background-color: white;
         overflow-x: clip;
         overflow-y: auto;
@@ -51,6 +56,17 @@ class slideDeck extends HTMLElement {
 
       :host([slide-view=list]) {
         ---slide-list-border: var(--slide-list-border, thin solid);
+      }
+
+      :host([blank-slide])::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-color: var(--blank-slide-color, black);
+      }
+
+      :host([blank-slide='white'])::after {
+        --blank-slide-color: white;
       }
 
       [part=contents] {
@@ -91,6 +107,14 @@ class slideDeck extends HTMLElement {
         );
         outline-offset: var(--slide-active-outline-offset, 3px);
       }
+
+      button[aria-pressed=true] {
+        box-shadow: inset 0 0 2px black;
+
+        &::before {
+          content: ' ✅ ';
+        }
+      }
     `);
     node.shadowRoot.adoptedStyleSheets = [shadowStyle];
   }
@@ -122,12 +146,41 @@ class slideDeck extends HTMLElement {
     'list',
   ];
 
+  static controlKeys = {
+    'Home': 'firstSlide',
+    'End': 'lastSlide',
+
+    // next slide
+    'ArrowRight': 'nextSlide',
+    'ArrowDown': 'nextSlide',
+    'PageDown': 'nextSlide',
+    'N': 'nextSlide',
+    ' ': 'nextSlide',
+
+    // previous slide
+    'ArrowLeft': 'previousSlide',
+    'ArrowUp': 'previousSlide',
+    'PageUp': 'previousSlide',
+    'P': 'previousSlide',
+    'Delete': 'previousSlide',
+
+    // blank slide
+    'B': 'blackOut',
+    '.': 'blackOut',
+    'W': 'whiteOut',
+    ',': 'whiteOut',
+
+    // end
+    '-': 'endPresentation'
+  }
+
   // dynamic
   store = {};
   slideCount;
   controlPanel;
   eventButtons;
   viewButtons;
+  activeSlide;
   body;
 
   // callbacks
@@ -143,10 +196,13 @@ class slideDeck extends HTMLElement {
         break;
       case 'slide-view':
         this.updateViewButtons();
+        this.scrollToActive();
         break;
       default:
         break;
     }
+
+    this.updateEventButtons();
   }
 
   constructor() {
@@ -165,7 +221,7 @@ class slideDeck extends HTMLElement {
     this.slideCount = this.childElementCount;
     this.defaultAttrs();
     this.setSlideIDs();
-    this.slideToStore();
+    this.goTo();
 
     // buttons
     this.setupEventButtons();
@@ -173,9 +229,10 @@ class slideDeck extends HTMLElement {
 
     // event listeners
     this.shadowRoot.addEventListener('keydown', (e) => {
+      e.stopPropagation();
+
       if (e.key === 'k' && e.metaKey) {
         e.preventDefault();
-        e.stopPropagation();
         this.controlPanel.close();
       }
     });
@@ -250,6 +307,23 @@ class slideDeck extends HTMLElement {
   };
 
   // buttons
+  getButtonEvent = (btn) => btn.getAttribute('slide-event') || btn.innerText;
+
+  updateEventButtons = () => {
+    this.eventButtons.forEach((btn) => {
+      const btnEvent = this.getButtonEvent(btn);
+      let isActive = {
+        'toggleControl': this.keyControl,
+        'toggleFollow': this.followActive,
+        'toggleFullscreen': this.fullScreen,
+      }
+
+      if (Object.keys(isActive).includes(btnEvent)) {
+        btn.setAttribute('aria-pressed', isActive[btnEvent]);
+      }
+    });
+  }
+
   setupEventButtons = () => {
     this.eventButtons = [
       ...this.querySelectorAll(`button[slide-event]`),
@@ -258,10 +332,12 @@ class slideDeck extends HTMLElement {
 
     this.eventButtons.forEach((btn) => {
       btn.addEventListener('click', (e) => {
-        const event = btn.getAttribute('slide-event') || btn.innerText;
+        const event = this.getButtonEvent(btn);
         this.dispatchEvent(new Event(event, { view: window, bubbles: false }));
       });
     });
+
+    this.updateEventButtons();
   }
 
   getButtonView = (btn) => btn.getAttribute('set-view') || btn.innerText;
@@ -335,6 +411,14 @@ class slideDeck extends HTMLElement {
     this.resetActive();
   }
 
+  toggleBlank = (color) => {
+    if (this.hasAttribute('blank-slide')) {
+      this.removeAttribute('blank-slide');
+    } else {
+      this.setAttribute('blank-slide', color || 'black');
+    }
+  }
+
   // dynamic attribute methods
   followActiveChange = () => {
     if (this.followActive) {
@@ -354,36 +438,62 @@ class slideDeck extends HTMLElement {
   }
 
   // storage
-  asSlideInt = (string) => parseInt(string, 10) || 1;
+  asSlideInt = (string) => parseInt(string, 10);
 
-  slideFromHash = (hash) => this.asSlideInt(hash.split('-').pop());
+  slideFromHash = () => window.location.hash.startsWith('#slide_')
+    ? this.asSlideInt(window.location.hash.split('-').pop())
+    : null;
   slideFromStore = () => this.asSlideInt(
     localStorage.getItem(this.store.slide)
   );
 
-  slideToHash = (to) => { window.location.hash = this.slideId(to) };
-  slideToStore = (to) => {
-    const active = to || this.slideFromHash(window.location.hash);
-    localStorage.setItem(this.store.slide, active);
+  slideToHash = (to) => {
+    if (to) {
+      window.location.hash = this.slideId(to);
+    }
   };
-
-  resetActive = () => {
-    window.location.hash = this.id;
-    localStorage.removeItem(this.store.slide);
+  slideToStore = (to) => {
+    if (to) {
+      localStorage.setItem(this.store.slide, to);
+    } else {
+      localStorage.removeItem(this.store.slide);
+    }
   };
 
   // navigation
   inRange = (slide) => slide >= 1 && slide <= this.slideCount;
+  getActive = () => this.slideFromHash() || this.activeSlide;
 
-  goTo = (slide) => {
-    if (this.inRange(slide)) {
-      this.slideToHash(slide);
-      this.slideToStore(slide);
+  scrollToActive = () => {
+    const activeEl = document.getElementById(this.slideId(this.activeSlide));
+
+    if (activeEl) {
+      activeEl.scrollIntoView(true);
     }
   };
 
+  goTo = (to) => {
+    const fromHash = this.slideFromHash();
+    const setTo = to || this.getActive();
+
+    if (setTo && this.inRange(setTo)) {
+      this.activeSlide = setTo;
+      this.slideToStore(setTo);
+
+      if (setTo !== fromHash) {
+        this.slideToHash(setTo);
+      }
+    }
+  }
+
+  resetActive = () => {
+    this.activeSlide = null;
+    window.location.hash = this.id;
+    localStorage.removeItem(this.store.slide);
+  };
+
   move = (by) => {
-    const to = this.slideFromHash(window.location.hash) + by;
+    const to = (this.getActive() || 0) + by;
     this.goTo(to);
   };
 
@@ -392,45 +502,84 @@ class slideDeck extends HTMLElement {
   }
 
   keyEventActions = (event) => {
+    // always available
     if (event.metaKey) {
       switch (event.key) {
         case 'k':
           event.preventDefault();
           this.controlPanel.showModal();
           break;
-        case '.':
-          event.preventDefault();
-          this.toggleAttribute('full-screen');
+        case 'f':
+          if (event.shiftKey) {
+            event.preventDefault();
+            this.toggleAttribute('full-screen');
+          }
+          break;
+        case 'Enter':
+          if (event.shiftKey) {
+            event.preventDefault();
+            this.startEvent();
+          } else {
+            event.preventDefault();
+            this.resumeEvent();
+          }
           break;
         default:
           break;
       }
-    }
-
-    if (event.target !== this.body) {
-      if (event.key === 'Escape') {
-        event.target.blur();
-      }
+      return;
+    } else if (event.altKey && event.key === 'Enter') {
+      event.preventDefault();
+      this.joinWithNotesEvent();
       return;
     }
 
+    // only while key-control is active
     if (this.keyControl) {
-      switch (event.key) {
-        case 'ArrowRight':
+      if (event.key === 'Escape') {
+        if (event.target !== this.body) {
+          event.target.blur();
+        } else {
+          event.preventDefault();
+          this.endEvent();
+        }
+        return;
+      }
+
+      if (event.metaKey && event.key === '.') {
+        event.preventDefault();
+        this.endEvent();
+        return;
+      }
+
+      switch (slideDeck.controlKeys[event.key]) {
+        case 'firstSlide':
+          event.preventDefault();
+          this.goTo(1);
+          break;
+        case 'lastSlide':
+          event.preventDefault();
+          this.goTo(this.slideCount);
+          break;
+        case 'nextSlide':
           event.preventDefault();
           this.move(1);
           break;
-        case 'PageDown':
-          event.preventDefault();
-          this.move(1);
-          break;
-        case 'ArrowLeft':
+        case 'previousSlide':
           event.preventDefault();
           this.move(-1);
           break;
-        case 'PageUp':
+        case 'blackOut':
           event.preventDefault();
-          this.move(-1);
+          this.toggleBlank('black');
+          break;
+        case 'whiteOut':
+          event.preventDefault();
+          this.toggleBlank('white');
+          break;
+        case 'endPresentation':
+          event.preventDefault();
+          this.endEvent();
           break;
         default:
           break;

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -377,10 +377,15 @@ class slideDeck extends HTMLElement {
 
   startEvent = () => {
     this.goTo(1);
-    this.resumeEvent();
+    this.startPresenting();
   }
 
   resumeEvent = () => {
+    this.goToSaved();
+    this.startPresenting();
+  }
+
+  startPresenting = () => {
     this.setAttribute('slide-view', 'list');
     this.setAttribute('key-control', '');
     this.setAttribute('follow-active', '');


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&snow)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->

- 💥 BREAKING: Updated keyboard shortcuts
  to match [PowerPoint](https://support.microsoft.com/en-us/office/use-keyboard-shortcuts-to-deliver-powerpoint-presentations-1524ffce-bd2a-45f4-9a7f-f18b992b93a0#bkmk_frequent_macos),
  including `command-.` as 'end presentation'
  rather than 'toggle full-screen' (now `command-shift-f`)
- 🚀 NEW: Support for blank-screen shortcuts
  (inspired by [Curtis Wilcox](https://codepen.io/ccwilcox/details/NWJWwOE))
- 🚀 NEW: Control panel includes toggle for keyboard controls
- 🚀 NEW: Control panel buttons have `aria-pressed` styles
- 🚀 NEW: All slide-event buttons that toggle a boolean state
  get `aria-pressed` values that update with the state
- 🐞 FIXED: Scroll to the active slide when changing views
- 🐞 FIXED: Control panel view toggles were broken
- 🐞 FIXED: Control panel prevents propagation of keyboard shortcuts
- 👀 INTERNAL: The current slide is stored in an `activeSlide` property

## Related Issue(s)
_Reminder to add related issue(s), if available._

- fixes #3 

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._

- try the various shortcuts
- try the buttons in the control panel