### PR TITLE
Restore active or first slide when turning on key control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 Breaking changes will be allowed in minor versions
 until we achieve a stable v1.0 release
 
+## v0.1.2 - unreleased
+
+- 🚀 NEW: When `key-control` is activated (including on-load),
+  we target the stored active slide (or the first slide)
+- 🐞 FIXED: When restoring the active slide from memory,
+  we go to the first slide if there's no stored state
+
 ## v0.1.1 - 2023-12-26
 
 - 💥 BREAKING: Updated keyboard shortcuts

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -188,6 +188,9 @@ class slideDeck extends HTMLElement {
     this[slideDeck.attrToPropMap[name]] = newValue || this.hasAttribute(name);
 
     switch (name) {
+      case 'key-control':
+        this.keyControlChange();
+        break;
       case 'follow-active':
         this.followActiveChange();
         break;
@@ -433,6 +436,12 @@ class slideDeck extends HTMLElement {
   }
 
   // dynamic attribute methods
+  keyControlChange = () => {
+    if (this.keyControl) {
+      this.goToSaved();
+    }
+  }
+
   followActiveChange = () => {
     if (this.followActive) {
       this.goToSaved();
@@ -503,7 +512,7 @@ class slideDeck extends HTMLElement {
   };
 
   goToSaved = () => {
-    this.goTo(this.slideFromStore());
+    this.goTo(this.slideFromStore() || 1);
   }
 
   keyEventActions = (event) => {


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&owl)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Related Issue(s)
_Reminder to add related issue(s), if available._

- Fixes #13 

## Steps to test/reproduce

- Load the demo, and note that a slide activates
- Remove the key-control attribute from the demo and reload, no slide should activate by default
- command-return to resume presenting, and the saved slide (or first slide) will activate
