### PR TITLE
Fix toggleView, add button

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,7 @@
         <div>
           <button set-view>list</button>
           <button set-view>grid</button>
+          <button slide-event="toggleView">toggle</button>
         </div>
       </div>
       <div><h2>Speaker View</h2></div>

--- a/index.html
+++ b/index.html
@@ -82,6 +82,7 @@
           <button slide-event>previous</button>
           <button slide-event>next</button>
           <button slide-event="start">restart</button>
+          <button slide-event="toggleView">toggle view</button>
         </div>
       </div>
       <div>
@@ -89,7 +90,6 @@
         <div>
           <button set-view>list</button>
           <button set-view>grid</button>
-          <button slide-event="toggleView">toggle</button>
         </div>
       </div>
       <div><h2>Speaker View</h2></div>

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -365,14 +365,15 @@ class slideDeck extends HTMLElement {
 
   // event handlers
   toggleView = (to) => {
-    if (!to) {
+    let next = to;
+    if (!next) {
       const current = this.getAttribute('slide-view');
-      const l = slideDeck.slideViews - 1; // adjust for 0-index
-      const i = slideDeck.slideViews.indexOf(current);
-      const next = slideDeck.slideViews[(i + 1) % l];
+      const l = slideDeck.slideViews.length;
+      const i = slideDeck.slideViews.indexOf(current) || 0;
+      next = slideDeck.slideViews[(i + 1) % l];
     }
 
-    this.setAttribute('slide-view', to || next || 'grid');
+    this.setAttribute('slide-view', next || 'grid');
   }
 
   startEvent = () => {


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&toggleView)

## Description
This fixes the logic for toggling between views, and adds an example button.

## Related Issue(s)
None


## Steps to test/reproduce
1. Click the `toggle view` button on the `slide-event` slide, and see that it it toggles between the two.
2. Set the `slide-view` attribute in the dom to something random, and click. See that it takes you to the default grid, and the toggles between grid and list.
