### PR TITLE
New slide-activate button attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ until we achieve a stable v1.0 release
 
 ## v0.1.3 - UNRELEASED
 
+- 🚀 NEW: Use the `to-slide` attribute on buttons in the slide deck
+  to move focus to any slide -- either the parent slide of the button,
+  or the slide index given as a value of the attribute
 - 🚀 NEW: Custom `goToSlide` event accepts an integer value
   in the `event.detail` property
 - 🚀 NEW: `--slide-count-string` and `--slide-index-string`
   can be used for CSS generated content
-- 🚀 NEW: Buttons with the `slide-activate` attribute
-  will activate the slide they are nested in
-  (with an optional value to set the slide-deck view)
 - 🐞 FIXED: Less nesting for lower specificity in the `slide-deck.css` theme
 - 🐞 FIXED: Provide shadow-DOM control-panel styles
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 Breaking changes will be allowed in minor versions
 until we achieve a stable v1.0 release
 
+## v0.1.3 - UNRELEASED
+
+- 🚀 NEW: Custom `goToSlide` event accepts an integer value
+  in the `event.detail` property
+- 🚀 NEW: `--slide-count-string` and `--slide-index-string`
+  can be used for CSS generated content
+- 🚀 NEW: Buttons with the `slide-activate` attribute
+  will activate the slide they are nested in
+  (with an optional value to set the slide-deck view)
+- 🐞 FIXED: Less nesting for lower specificity in the `slide-deck.css` theme
+- 🐞 FIXED: Provide shadow-DOM control-panel styles
+
 ## v0.1.2 - 2024-01-16
 
 - 💥 BREAKING: Disabled the full-screen keyboard shortcut,

--- a/index.html
+++ b/index.html
@@ -239,8 +239,12 @@
             <button slide-event>previous</button>
             <button slide-event>next</button>
             <button slide-event>reset</button>
-            <button slide-activate="solo">
-              activate this slide in solo view
+            <hr>
+            <button set-view="solo" to-slide>
+              go to this slide, in solo view
+            </button>
+            <button to-slide="6">
+              go to slide 6
             </button>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -148,11 +148,6 @@
             (in case you are using multiple tabs
             for differnt views).
           </p>
-          <p>
-            Ending a presentation
-            returns you to the grid layout,
-            turning off key-control and active-follow.
-          </p>
         </div>
       </div>
       <div>
@@ -243,7 +238,10 @@
           <div>
             <button slide-event>previous</button>
             <button slide-event>next</button>
-            <button slide-event="start">restart</button>
+            <button slide-event>reset</button>
+            <button slide-activate="solo">
+              activate this slide in solo view
+            </button>
           </div>
         </div>
         <div slide-note>

--- a/slide-deck.css
+++ b/slide-deck.css
@@ -1,6 +1,6 @@
 slide-deck {
   --gap: clamp(8px, 0.25em + 1vw, 16px);
-  --slide-border: thin solid gray;
+  --default-slide-border: thin solid gray;
   container: slide-deck slide / inline-size;
   display: grid;
 }
@@ -16,7 +16,7 @@ slide-deck {
 }
 
 [slide-view=grid] {
-  --apply-slide-border: thin solid gray;
+  --slide-canvas-border: var(--default-slide-border);
   --slide-note-margin-block: var(--gap);
   grid-template-columns: repeat(auto-fill, minmax(min(50ch, 100%), 1fr));
 }
@@ -29,7 +29,7 @@ slide-deck {
   }
 
   [slide-canvas] {
-    border-block-end: var(--slide-border);
+    border-block-end: var(--default-slide-border);
   }
 
   [slide-note] {
@@ -38,7 +38,7 @@ slide-deck {
 }
 
 [slide-view=script] {
-  --apply-slide-border: thin solid gray;
+  --slide-canvas-border: var(--default-slide-border);
   --column-gap: calc(1.25em + 2vw);
   --row-gap: 5em;
   display: grid;
@@ -76,7 +76,7 @@ slide-deck {
 
 [slide-canvas] {
   aspect-ratio: var(--slide-ratio);
-  border: var(--apply-slide-border);
+  border: var(--slide-canvas-border);
   container: slide / inline-size;
   padding: var(--gap);
 

--- a/slide-deck.css
+++ b/slide-deck.css
@@ -1,117 +1,92 @@
 slide-deck {
   --gap: clamp(8px, 0.25em + 1vw, 16px);
-  container: slide-deck / inline-size;
+  --slide-border: thin solid gray;
+  container: slide-deck slide / inline-size;
   display: grid;
+}
 
-  &[slide-view=grid],
-  &[slide-view=script] {
-    --slide-ratio: 16/9;
-    --target-margin: var(--gap);
-    --target-outline: medium dotted;
-    --target-outline-offset: calc(var(--gap) * 0.5);
-    gap: var(--row-gap, var(--gap)) var(--column-gap, var(--gap));
-    padding: var(--gap);
-  }
+[slide-view=grid],
+[slide-view=script] {
+  --slide-ratio: 16/9;
+  --target-margin: var(--gap);
+  --target-outline: medium dotted;
+  --target-outline-offset: calc(var(--gap) * 0.5);
+  gap: var(--row-gap, var(--gap)) var(--column-gap, var(--gap));
+  padding: var(--gap);
+}
 
-  &[slide-view=grid] {
-    --slide-note-margin-block: var(--gap);
-    grid-template-columns: repeat(auto-fill, minmax(min(50ch, 100%), 1fr));
-  }
+[slide-view=grid] {
+  --apply-slide-border: thin solid gray;
+  --slide-note-margin-block: var(--gap);
+  grid-template-columns: repeat(auto-fill, minmax(min(50ch, 100%), 1fr));
+}
 
-  &[slide-view=solo] {
-    grid-auto-rows: 100svh;
+[slide-view=solo] {
+  grid-auto-rows: 100svh;
 
-    [slide-item='container'] {
-      display: grid;
-    }
-
-    [slide-note] {
-      display: none;
-    }
-  }
-
-  &[slide-view=script] {
-    --column-gap: calc(1.25em + 2vw);
-    --row-gap: 5em;
+  [slide-item='container'] {
     display: grid;
-
-    @media (width >= 60em) {
-      grid-template-columns: minmax(30vw, auto) minmax(65vw, 1fr);
-    }
-
-    [slide-item='container'] {
-      align-items: center;
-      display: grid;
-      grid-column: 1 / -1;
-      grid-template-columns: subgrid;
-    }
-
-    [slide-canvas] {
-      grid-column: 1;
-      scale: var(--scaled-slide, 0.80);
-    }
-
-    [slide-note] {
-      font-size: var(--note-font-size, 120%);
-      grid-column: 2;
-      max-width: 75ch;
-      padding-inline: var(--gap);
-    }
-
-    [slide-item]:target {
-      --note-font-size: 160%;
-      --scaled-slide: 1;
-    }
-  }
-
-  [slide-item] {
-    scroll-margin-block: var(--target-margin);
-  }
-
-  [aria-current='true'][slide-canvas],
-  [aria-current='true'] [slide-canvas] {
-    outline: var(--target-outline);
-    outline-offset: var(--target-outline-offset);
   }
 
   [slide-canvas] {
-    aspect-ratio: var(--slide-ratio);
-    border: thin solid;
-    box-sizing: border-box;
-    container: slide-item / inline-size;
-    padding: var(--gap);
+    border-block-end: var(--slide-border);
   }
 
   [slide-note] {
-    margin-block: var(--slide-note-margin-block);
+    display: none;
+  }
+}
+
+[slide-view=script] {
+  --apply-slide-border: thin solid gray;
+  --column-gap: calc(1.25em + 2vw);
+  --row-gap: 5em;
+  display: grid;
+
+  @media (width >= 60em) {
+    grid-template-columns: minmax(30vw, auto) minmax(65vw, 1fr);
   }
 
-  &::part(control-panel) {
-    min-width: min(50ch, 100%);
-    padding: 0;
-  }
-
-  &::part(panel-header) {
-    border-block-end: thin solid;
+  [slide-item='container'] {
+    align-items: center;
     display: grid;
-    gap: var(--gap);
-    grid-template-columns: 1fr auto;
-    padding: var(--gap);
+    grid-column: 1 / -1;
+    grid-template-columns: subgrid;
   }
 
-  &::part(controls) {
-    padding: var(--gap);
+  [slide-canvas] {
+    grid-column: 1;
   }
 
-  button,
-  &::part(button) {
-    border: medium solid transparent;
-    font: inherit;
+  [slide-note] {
+    font-size: var(--note-font-size, 120%);
+    grid-column: 2;
+    max-width: 75ch;
     padding-inline: var(--gap);
   }
 
-  [aria-pressed=true],
-  &::part(pressed) {
-    border-color: currentColor;
+  [slide-item]:target {
+    --note-font-size: 160%;
   }
+}
+
+[slide-item] {
+  scroll-margin-block: var(--target-margin);
+}
+
+[slide-canvas] {
+  aspect-ratio: var(--slide-ratio);
+  border: var(--apply-slide-border);
+  container: slide / inline-size;
+  padding: var(--gap);
+
+  &:where([aria-current='true']),
+  &:where([slide-item][aria-current='true'] *) {
+    outline: var(--target-outline);
+    outline-offset: var(--target-outline-offset);
+  }
+}
+
+[slide-note] {
+  margin-block: var(--slide-note-margin-block);
 }

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -199,6 +199,7 @@ class slideDeck extends HTMLElement {
   #blankSlide;
   #eventButtons;
   #viewButtons;
+  #goToButtons;
   #body;
 
   // callbacks
@@ -245,6 +246,7 @@ class slideDeck extends HTMLElement {
     // buttons
     this.#setupEventButtons();
     this.#setupViewButtons();
+    this.#setupGoToButtons();
 
     // shadow DOM event listeners
     this.shadowRoot.addEventListener('keydown', (event) => {
@@ -290,6 +292,8 @@ class slideDeck extends HTMLElement {
   }
 
   // setup methods
+  #cleanString = (str) => str.trim().toLowerCase();
+
   #newDeckId = (from, count) => {
     const base = from || window.location.pathname.split('.')[0];
     const ID = count ? `${base}-${count}` : base;
@@ -323,14 +327,6 @@ class slideDeck extends HTMLElement {
       slide.id = this.#slideId(slideIndex);
       slide.style.setProperty('--slide-index', slideIndex);
       slide.style.setProperty('--slide-index-string', `'${slideIndex}'`);
-
-      slide.querySelectorAll(':scope button[slide-activate]').forEach((btn) => {
-        btn.addEventListener('click', () => {
-          this.goTo(slideIndex)
-          const inView = btn.getAttribute('slide-activate');
-          if (inView) { this.setAttribute('slide-view', inView); }
-        });
-      });
 
       if (slide.querySelector(':scope [slide-canvas]')) {
         if (!slide.hasAttribute('slide-item')) {
@@ -367,7 +363,7 @@ class slideDeck extends HTMLElement {
     ...this.shadowRoot.querySelectorAll(`button[${attr}]`),
   ];
 
-  #getButtonValue = (btn, attr) => btn.getAttribute(attr) || btn.innerText.trim();
+  #getButtonValue = (btn, attr) => this.#cleanString(btn.getAttribute(attr) || btn.innerText);
 
   #setButtonPressed = (btn, isPressed) => {
     btn.setAttribute('aria-pressed', isPressed);
@@ -391,6 +387,23 @@ class slideDeck extends HTMLElement {
   #setToggleState = (btn, attr, state) => {
     const isActive = this.#getButtonValue(btn, attr) === state;
     this.#setButtonPressed(btn, isActive);
+  }
+
+  #setupGoToButtons = () => {
+    this.#goToButtons = this.#findButtons('to-slide');
+
+    this.#goToButtons.forEach((btn) => {
+      const btnValue = btn.getAttribute('to-slide');
+      const btnSlide = btn.closest("[slide-item]");
+
+      const toSlide = btnValue
+        ? this.#asSlideInt(btnValue)
+        : this.#indexFromId(btnSlide.id);
+
+      btn.addEventListener('click', (e) => {
+        this.goTo(toSlide);
+      });
+    });
   }
 
   #setupViewButtons = () => {

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -24,10 +24,10 @@ class slideDeck extends HTMLElement {
               start
             </button>
             <button part="button event" slide-event>
-              reset
+              resume
             </button>
-            <button part="button event" slide-event="joinWithNotes">
-              speaker view
+            <button part="button event" slide-event>
+              reset
             </button>
 
             <hr>
@@ -63,6 +63,41 @@ class slideDeck extends HTMLElement {
   static #adoptShadowStyles = (node) => {
     const shadowStyle = new CSSStyleSheet();
     shadowStyle.replaceSync(`
+      [part=control-panel] {
+        --sd-panel-gap: clamp(8px, 0.25em + 1vw, 24px);
+        min-width: min(50ch, 100%);
+        padding: 0;
+      }
+
+      [part=panel-header] {
+        align-items: center;
+        border-block-end: thin solid gray;
+        display: grid;
+        gap: var(--sd-panel-gap);
+        grid-template-columns: 1fr auto;
+        padding: var(--sd-panel-gap);
+      }
+
+      [part=controls] {
+        padding: var(--sd-panel-gap);
+      }
+
+      hr {
+        border-block-start: thin dotted gray;
+        border-block-end: none;
+        margin-block: 1lh;
+      }
+
+      [part~=button] {
+        border: medium solid transparent;
+        font: inherit;
+        padding-inline: var(--sd-panel-gap);
+
+        &[aria-pressed=true] {
+          border-color: currentColor;
+        }
+      }
+
       [part=blank-slide],
       ::slotted([slot=blank-slide]) {
         block-size: 100%;
@@ -234,15 +269,16 @@ class slideDeck extends HTMLElement {
     this.addEventListener('toggleFullscreen', (e) => this.fullScreenEvent());
 
     this.addEventListener('join', (e) => this.joinEvent());
-    this.addEventListener('joinWithNotes', (e) => this.joinWithNotesEvent());
     this.addEventListener('start', (e) => this.startEvent());
     this.addEventListener('resume', (e) => this.resumeEvent());
     this.addEventListener('reset', (e) => this.resetEvent());
     this.addEventListener('blankSlide', (e) => this.blankSlideEvent());
+    this.addEventListener('joinWithNotes', (e) => this.joinWithNotesEvent());
 
     this.addEventListener('next', (e) => this.move(1));
     this.addEventListener('savedSlide', (e) => this.goToSaved());
     this.addEventListener('previous', (e) => this.move(-1));
+    this.addEventListener('goToSlide', (e) => this.goTo(e.detail));
   };
 
   connectedCallback() {
@@ -280,11 +316,21 @@ class slideDeck extends HTMLElement {
     this.slides = this.querySelectorAll(':scope > :not([slot])');
     this.slideCount = this.slides.length;
     this.style.setProperty('--slide-count', this.slideCount);
+    this.style.setProperty('--slide-count-string', `'${this.slideCount}'`);
 
     this.slides.forEach((slide, index) => {
       const slideIndex = index + 1;
       slide.id = this.#slideId(slideIndex);
       slide.style.setProperty('--slide-index', slideIndex);
+      slide.style.setProperty('--slide-index-string', `'${slideIndex}'`);
+
+      slide.querySelectorAll(':scope button[slide-activate]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          this.goTo(slideIndex)
+          const inView = btn.getAttribute('slide-activate');
+          if (inView) { this.setAttribute('slide-view', inView); }
+        });
+      });
 
       if (slide.querySelector(':scope [slide-canvas]')) {
         if (!slide.hasAttribute('slide-item')) {
@@ -321,7 +367,7 @@ class slideDeck extends HTMLElement {
     ...this.shadowRoot.querySelectorAll(`button[${attr}]`),
   ];
 
-  #getButtonValue = (btn, attr) => btn.getAttribute(attr) || btn.innerText;
+  #getButtonValue = (btn, attr) => btn.getAttribute(attr) || btn.innerText.trim();
 
   #setButtonPressed = (btn, isPressed) => {
     btn.setAttribute('aria-pressed', isPressed);
@@ -418,6 +464,10 @@ class slideDeck extends HTMLElement {
     this.#startPresenting();
   }
 
+  resetEvent = () => {
+    this.goTo(1);
+  }
+
   joinWithNotesEvent = () => {
     this.setAttribute('slide-view', 'script');
     this.setAttribute('key-control', '');
@@ -427,10 +477,6 @@ class slideDeck extends HTMLElement {
   joinEvent = () => {
     this.setAttribute('key-control', '');
     this.setAttribute('follow-active', '');
-  }
-
-  resetEvent = () => {
-    this.goTo(1);
   }
 
   blankSlideEvent = (color) => {


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&eyes)

## Description

I was on my flight, and I thought I would quickly add:

- Activate-current-slide buttons
- String versions of the number custom properties

## Related Issue(s)
_Reminder to add related issue(s), if available._

I found I had already started on #27, so I decided to put that in the PR as well. Here are the changes (_with some notes_):

- 🚀 NEW: Custom `goToSlide` event accepts an integer value in the `event.detail` property
  - _I added the event, but maybe we also want a specialized button attribute that does this? Should it have a similar name to the activate-current-slide button attribute?_
- 🚀 NEW: Buttons with the `slide-activate` attribute will activate the slide they are nested in (with an optional value to set the slide-deck view)
  - _I started by adding the `goToSlide` event, and then realized this feature worked better without it. But both seem useful, and maybe there should be a more consistent syntax between them? I'd like input._
- 🚀 NEW: `--slide-count-string` and `--slide-index-string` can be used for CSS generated content
- 🐞 FIXED: Less nesting for lower specificity in the `slide-deck.css` theme
- 🐞 FIXED: Provide shadow-DOM control-panel styles
