### PR TITLE
Fix broken events (now lowercase)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ until we achieve a stable v1.0 release
 
 ## v0.1.3 - UNRELEASED
 
+- 💥 BREAKING: All events and `slide-event` controls use
+  lowercase hyphenated names, for consistency with html conventions
+  (`toggleControl` -> `toggle-control`,
+  `toggleFollow` -> `toggle-follow`,
+  `toggleFullscreen` -> `toggle-fullscreen`)
 - 🚀 NEW: Use the `to-slide` attribute on buttons in the slide deck
   to move focus to any slide -- either the parent slide of the button,
   or the slide index given as a value of the attribute

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -291,7 +291,7 @@ class slideDeck extends HTMLElement {
   }
 
   // setup methods
-  #cleanString = (str, lower = true) => str.trim().toLowerCase();
+  #cleanString = (str) => str.trim().toLowerCase();
 
   #newDeckId = (from, count) => {
     const base = from || window.location.pathname.split('.')[0];

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -13,7 +13,7 @@ class slideDeck extends HTMLElement {
             </form>
           </div>
           <div part="controls">
-            <button part="button" slide-event='toggleControl'>
+            <button part="button" slide-event='toggle-control'>
               keyboard navigation
             </button>
 
@@ -211,7 +211,6 @@ class slideDeck extends HTMLElement {
         break;
       case 'follow-active':
         this.#followActiveChange();
-        this.#updateEventButtons();
         break;
       case 'slide-view':
         this.#onViewChange();
@@ -266,21 +265,21 @@ class slideDeck extends HTMLElement {
     })
 
     // custom events
-    this.addEventListener('toggleControl', (e) => this.toggleAttribute('key-control'));
-    this.addEventListener('toggleFollow', (e) => this.toggleAttribute('follow-active'));
-    this.addEventListener('toggleFullscreen', (e) => this.fullScreenEvent());
+    this.addEventListener('toggle-control', (e) => this.toggleAttribute('key-control'));
+    this.addEventListener('toggle-follow', (e) => this.toggleAttribute('follow-active'));
+    this.addEventListener('toggle-fullscreen', (e) => this.fullScreenEvent());
 
     this.addEventListener('join', (e) => this.joinEvent());
     this.addEventListener('start', (e) => this.startEvent());
     this.addEventListener('resume', (e) => this.resumeEvent());
     this.addEventListener('reset', (e) => this.resetEvent());
-    this.addEventListener('blankSlide', (e) => this.blankSlideEvent());
-    this.addEventListener('joinWithNotes', (e) => this.joinWithNotesEvent());
+    this.addEventListener('blank-slide', (e) => this.blankSlideEvent());
+    this.addEventListener('join-with-notes', (e) => this.joinWithNotesEvent());
 
     this.addEventListener('next', (e) => this.move(1));
-    this.addEventListener('savedSlide', (e) => this.goToSaved());
+    this.addEventListener('saved-slide', (e) => this.goToSaved());
     this.addEventListener('previous', (e) => this.move(-1));
-    this.addEventListener('goToSlide', (e) => this.goTo(e.detail));
+    this.addEventListener('to-slide', (e) => this.goTo(e.detail));
   };
 
   connectedCallback() {
@@ -292,7 +291,7 @@ class slideDeck extends HTMLElement {
   }
 
   // setup methods
-  #cleanString = (str) => str.trim().toLowerCase();
+  #cleanString = (str, lower = true) => str.trim().toLowerCase();
 
   #newDeckId = (from, count) => {
     const base = from || window.location.pathname.split('.')[0];
@@ -363,7 +362,9 @@ class slideDeck extends HTMLElement {
     ...this.shadowRoot.querySelectorAll(`button[${attr}]`),
   ];
 
-  #getButtonValue = (btn, attr) => this.#cleanString(btn.getAttribute(attr) || btn.innerText);
+  #getButtonValue = (btn, attr, lower=true) => this.#cleanString(
+    btn.getAttribute(attr) || btn.innerText
+  );
 
   #setButtonPressed = (btn, isPressed) => {
     btn.setAttribute('aria-pressed', isPressed);
@@ -449,9 +450,9 @@ class slideDeck extends HTMLElement {
       const btnEvent = this.#getButtonValue(btn, 'slide-event');
 
       let isActive = {
-        'toggleControl': this.keyControl,
-        'toggleFollow': this.followActive,
-        'toggleFullscreen': this.fullScreen,
+        'toggle-control': this.keyControl,
+        'toggle-follow': this.followActive,
+        'toggle-fullscreen': this.fullScreen,
       }
 
       if (Object.keys(isActive).includes(btnEvent)) {


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&broken)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description
Uncomment if you want to provide a custom description.

Stacy pointed out in the previous PR #29 that I broke some of the events. That's because event-names were camelCase, and I added a value-cleanup function that would lowercase the strings. I think that was a good change, and we should _also_ make event names lower-kebab-case.

## Steps to test/reproduce

In the demo, it was specifically the key-control toggle that was broken. That should be working again in this PR.
