### PR TITLE
An attempt at some code cleanup, renaming things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ until we achieve a stable v1.0 release
 ## v0.2.0 - UNRELEASED
 
 - 💥 BREAKING: The component itself is only aware of two 'built-in' views,
-  named `presentation` (used for `start` and `resume` events)
+  named `slideshow` (used for `start` and `resume` events)
   and `speaker` (used for the `join-as-speaker` event)
 - 💥 BREAKING: Renamed the custom event handlers and matching public methods:
   - `reset` = `reset()`
@@ -18,9 +18,9 @@ until we achieve a stable v1.0 release
   - `blank-slide` = `blankSlide()`
   - `next` = `next()`
   - `previous` = `previous()`
-  - `to-slide` = `goTo()`
-  - `to-saved` = `goToSaved()`
-  - `to-saved` = `goToSaved()`
+  - `to-slide` = `toSlide()`
+  - `to-saved` = `toSavedSlide()`
+  - `scroll-to-active` = `scrollToActive()`
   - `full-screen` = `toggleFullScreen()`
   - `key-control` = `toggleKeyControl()`
   - `follow-active` = `toggleFollowActive()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@
 Breaking changes will be allowed in minor versions
 until we achieve a stable v1.0 release
 
+## v0.2.0 - UNRELEASED
+
+- 💥 BREAKING: The component itself is only aware of two 'built-in' views,
+  named `presentation` (used for `start` and `resume` events)
+  and `speaker` (used for the `join-as-speaker` event)
+- 💥 BREAKING: Renamed the custom event handlers and matching public methods:
+  - `reset` = `reset()`
+  - `join` = `join()`
+  - `resume` = `resume()`
+  - `start` = `start()`
+  - `join-as-speaker` = `joinAsSpeaker()`
+  - `blank-slide` = `blankSlide()`
+  - `next` = `next()`
+  - `previous` = `previous()`
+  - `to-slide` = `goTo()`
+  - `to-saved` = `goToSaved()`
+  - `to-saved` = `goToSaved()`
+  - `full-screen` = `toggleFullScreen()`
+  - `key-control` = `toggleKeyControl()`
+  - `follow-active` = `toggleFollowActive()`
+- 🐞 FIXED: Keyboard events are given proper priority, so that
+  (for example) you can open the control panel from a blank slide
+
 ## v0.1.4 - 2024-02-28
 
 - 🐞 FIXED: session view preference overrides attribute

--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ Always available:
 - `command-k`: Toggle control panel
 - `command-shift-enter`: Start presentation (from first slide)
 - `command-enter`: Resume presentation (from active slide)
-- `command-.`: End presentation
+- `alt-enter`: Join presentation in speaker view (from active slide)
 
 *Windows and Linux users can use Ctrl instead of Command.*
 
-When presenting (key-control is active):
+When presenting (`key-control` is active):
 
 - `N`/`rightArrow`/`downArrow`/`pageDown`: Next slide
 - `P`/`leftArrow`/`upArrow`/`pageUp`: Previous slide

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ When presenting (`key-control` is active):
 - `end`: Last slide
 - `W`/`,`: Toggle white screen
 - `B`/`.`: Toggle black screen
-- `escape`: Blur focused element, close control panel, or end presentation
+- `escape`: Blur focused element or close control panel
 
 These are based on
 the [PowerPoint shortcuts](https://support.microsoft.com/en-us/office/use-keyboard-shortcuts-to-deliver-powerpoint-presentations-1524ffce-bd2a-45f4-9a7f-f18b992b93a0#bkmk_frequent_macos).

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <script type="module" src="slide-deck.js"></script>
   </head>
   <body>
-    <slide-deck id="my-slides" key-control slide-view="presentation">
+    <slide-deck id="my-slides" key-control>
       <header>
         <div slide-canvas>
           <h1>Slide-Deck Web Component</h1>
@@ -21,9 +21,9 @@
           </p>
           <p>
             View as…
-            <button set-view="grid">grid</button>
-            <button set-view="speaker">speaker</button>
-            <button set-view="presentation">slideshow presentation</button>
+            <button set-view>grid</button>
+            <button set-view>slideshow</button>
+            <button set-view>speaker</button>
           </p>
           <p>
             Use arrow keys to navigate. Or scroll instead.
@@ -36,7 +36,7 @@
       </header>
       <div>
         <h2>No Dependencies</h2>
-        <p>This is a stand-alone web compontent</p>
+        <p>This is a stand-alone web component</p>
       </div>
       <div>
         <div slide-canvas>
@@ -147,11 +147,10 @@
         <div slide-note>
           <p>
             Starting a presentation
-            takes you into full-page slide view,
+            takes you into the slideshow view,
             with keyboard controls on,
             and following active-slide changes in local-storage
-            (in case you are using multiple tabs
-            for differnt views).
+            (in case you are using multiple tabs for different views).
           </p>
         </div>
       </div>
@@ -245,8 +244,8 @@
             <button slide-event>next</button>
             <button slide-event>reset</button>
             <hr>
-            <button set-view="presentation" to-slide>
-              go to this slide, in presentation view
+            <button set-view="slideshow" to-slide>
+              go to this slide, in slideshow view
             </button>
             <button to-slide="6">
               go to slide 6
@@ -264,9 +263,9 @@
       </div>
       <div>
         <div slide-canvas>
-          <h2><code>&lt;button set-view&gt;presentation&lt;button&gt;</code></h2>
+          <h2><code>&lt;button set-view&gt;slideshow&lt;button&gt;</code></h2>
           <div>
-            <button set-view>presentation</button>
+            <button set-view>slideshow</button>
             <button set-view>grid</button>
             <button set-view>speaker</button>
           </div>

--- a/index.html
+++ b/index.html
@@ -140,6 +140,7 @@
             <li><strong>command-k</strong>: Toggle control panel</li>
             <li><strong>command-shift-enter</strong>: Start presentation (from first slide)</li>
             <li><strong>command-enter</strong>: Resume presentation (from active slide)</li>
+            <li><strong>alt-enter</strong>: Join presentation in speaker view (from active slide)</li>
           </ul>
           <p>Windows and Linux users can use Ctrl instead of Command.</p>
         </div>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <script type="module" src="slide-deck.js"></script>
   </head>
   <body>
-    <slide-deck id="my-slides" key-control slide-view="solo">
+    <slide-deck id="my-slides" key-control slide-view="presentation">
       <header>
         <div slide-canvas>
           <h1>Slide-Deck Web Component</h1>
@@ -22,8 +22,8 @@
           <p>
             View as…
             <button set-view="grid">grid</button>
-            <button set-view="script">script</button>
-            <button set-view="solo">full-page</button>
+            <button set-view="speaker">speaker</button>
+            <button set-view="presentation">slideshow presentation</button>
           </p>
           <p>
             Use arrow keys to navigate. Or scroll instead.
@@ -62,7 +62,7 @@
             Slide notes are also HTML
           </h3>
           <p>
-            In <button set-view='script'>script view</button>
+            In <button set-view='speaker'>speaker view</button>
             the active slide-item will have a larger canvas size
             and the font-size of an active slides speaker notes is increased
             for easier readability.
@@ -244,8 +244,8 @@
             <button slide-event>next</button>
             <button slide-event>reset</button>
             <hr>
-            <button set-view="solo" to-slide>
-              go to this slide, in solo view
+            <button set-view="presentation" to-slide>
+              go to this slide, in presentation view
             </button>
             <button to-slide="6">
               go to slide 6
@@ -263,11 +263,11 @@
       </div>
       <div>
         <div slide-canvas>
-          <h2><code>&lt;button set-view&gt;solo&lt;button&gt;</code></h2>
+          <h2><code>&lt;button set-view&gt;presentation&lt;button&gt;</code></h2>
           <div>
-            <button set-view>solo</button>
+            <button set-view>presentation</button>
             <button set-view>grid</button>
-            <button set-view>script</button>
+            <button set-view>speaker</button>
           </div>
         </div>
         <div slide-note>

--- a/slide-deck.css
+++ b/slide-deck.css
@@ -6,7 +6,7 @@ slide-deck {
 }
 
 [slide-view=grid],
-[slide-view=script] {
+[slide-view=speaker] {
   --slide-ratio: 16/9;
   --target-margin: var(--gap);
   --target-outline: medium dotted;
@@ -21,7 +21,7 @@ slide-deck {
   grid-template-columns: repeat(auto-fill, minmax(min(50ch, 100%), 1fr));
 }
 
-[slide-view=solo] {
+[slide-view=presentation] {
   grid-auto-rows: 100svh;
 
   [slide-item='container'] {
@@ -37,7 +37,7 @@ slide-deck {
   }
 }
 
-[slide-view=script] {
+[slide-view=speaker] {
   --slide-canvas-border: var(--default-slide-border);
   --column-gap: calc(1.25em + 2vw);
   --row-gap: 5em;

--- a/slide-deck.css
+++ b/slide-deck.css
@@ -21,7 +21,7 @@ slide-deck {
   grid-template-columns: repeat(auto-fill, minmax(min(50ch, 100%), 1fr));
 }
 
-[slide-view=presentation] {
+[slide-view=slideshow] {
   grid-auto-rows: 100svh;
 
   [slide-item='container'] {

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -268,12 +268,12 @@ class slideDeck extends HTMLElement {
 
     // events
     this.#body.addEventListener('keydown', this.#bodyKeyEvents);
-    this.#blankSlide.addEventListener('close', this.#blankSlideCloseEvent);
+    this.#blankSlide.addEventListener('close', this.#blankSlideClosed);
   }
 
   disconnectedCallback() {
     this.#body.removeEventListener('keydown', this.#bodyKeyEvents);
-    this.#blankSlide.removeEventListener('close', this.#blankSlideCloseEvent);
+    this.#blankSlide.removeEventListener('close', this.#blankSlideClosed);
   }
 
   // --------------------------------------------------------------------------
@@ -474,11 +474,14 @@ class slideDeck extends HTMLElement {
   blankSlide = (color) => {
     if (this.#blankSlide.open) {
       this.#blankSlide.close();
-      this.removeAttribute('blank-slide');
     } else {
       this.#blankSlide.showModal();
       this.setAttribute('blank-slide', color || 'black');
     }
+  }
+
+  #blankSlideClosed = () => {
+    this.removeAttribute('blank-slide');
   }
 
   toggleFullScreen = () => {
@@ -593,10 +596,6 @@ class slideDeck extends HTMLElement {
 
   // Detect Ctrl / Cmd modifiers in a platform-agnostic way
   #cmdOrCtrl = (event) => event.ctrlKey || event.metaKey;
-
-  #blankSlideCloseEvent = (event) => {
-    this.removeAttribute('blank-slide');
-  }
 
   #escToBlur = (event) => {
     if (event.key === 'Escape') {

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -620,6 +620,7 @@ class slideDeck extends HTMLElement {
   #bodyKeyEvents = (event) => {
     // modal events
     if (event.key === 'k' && this.#cmdOrCtrl(event)) {
+      event.preventDefault();
       this.#controlPanel.open
         ? this.#controlPanel.close()
         : this.#controlPanel.showModal();

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -617,7 +617,7 @@ class slideDeck extends HTMLElement {
     }
   }
 
-  #isPrivateKeydown = (event) => {
+        const type = event.target.getAttribute('type')?.toLowerCase();
     // it's only private if the focus is somewhere else
     if (event.target === this.#body) { return; }
 

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -24,7 +24,7 @@ class slideDeck extends HTMLElement {
             <button part="button event" slide-event="start">
               start slideshow
             </button>
-            <button part="button event">
+            <button part="button event" slide-event>
               resume
             </button>
             <button part="button event" slide-event>
@@ -282,7 +282,7 @@ class slideDeck extends HTMLElement {
   // --------------------------------------------------------------------------
   // setup methods
 
-  #cleanString = (str) => str.trim().toLowerCase().replace(' ', '-');
+  #cleanString = (str) => str.trim().toLowerCase().replaceAll(' ', '-');
 
   #newDeckId = (from, count) => {
     const base = from || window.location.pathname.split('.')[0];

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -233,22 +233,22 @@ class slideDeck extends HTMLElement {
     this.#setDeckID();
 
     // custom events
-    this.addEventListener('key-control', (e) => this.toggleKeyControl());
-    this.addEventListener('follow-active', (e) => this.toggleFollowActive());
-    this.addEventListener('full-screen', (e) => this.toggleFullScreen());
+    this.addEventListener('key-control', this.toggleKeyControl);
+    this.addEventListener('follow-active', this.toggleFollowActive);
+    this.addEventListener('full-screen', this.toggleFullScreen);
 
-    this.addEventListener('join', (e) => this.join());
-    this.addEventListener('start', (e) => this.start());
-    this.addEventListener('resume', (e) => this.resume());
-    this.addEventListener('reset', (e) => this.reset());
-    this.addEventListener('blank-slide', (e) => this.blankSlide());
-    this.addEventListener('join-as-speaker', (e) => this.joinAsSpeaker());
+    this.addEventListener('join', this.join);
+    this.addEventListener('start', this.start);
+    this.addEventListener('resume', this.resume);
+    this.addEventListener('reset', this.reset);
+    this.addEventListener('blank-slide', this.blankSlide);
+    this.addEventListener('join-as-speaker', this.joinAsSpeaker);
 
-    this.addEventListener('next', (e) => this.next());
-    this.addEventListener('previous', (e) => this.previous());
+    this.addEventListener('next', this.next);
+    this.addEventListener('previous', this.previous);
     this.addEventListener('to-slide', (e) => this.toSlide(e.detail));
-    this.addEventListener('to-saved', (e) => this.toSavedSlide());
-    this.addEventListener('scroll-to-active', (e) => this.scrollToActive());
+    this.addEventListener('to-saved', this.toSavedSlide);
+    this.addEventListener('scroll-to-active', this.scrollToActive);
   };
 
   connectedCallback() {
@@ -438,9 +438,9 @@ class slideDeck extends HTMLElement {
       const btnEvent = this.#getButtonValue(btn, 'slide-event');
 
       let isActive = {
-        'toggle-control': this.keyControl,
-        'toggle-follow': this.followActive,
-        'toggle-fullscreen': this.fullScreen,
+        'key-control': this.keyControl,
+        'follow-active': this.followActive,
+        'full-screen': this.fullScreen,
       }
 
       if (Object.keys(isActive).includes(btnEvent)) {

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -1,5 +1,10 @@
 class slideDeck extends HTMLElement {
 
+  static knownViews = {
+    public: 'presentation',
+    private: 'speaker',
+  };
+
   // --------------------------------------------------------------------------
   // shadow DOM (control panel & blank slide)
 
@@ -17,13 +22,13 @@ class slideDeck extends HTMLElement {
           </div>
           <div part="controls">
             <button part="button event" slide-event="start">
-              start presenting
+              start presentation
             </button>
-            <button part="button event" slide-event>
+            <button part="button event">
               resume
             </button>
-            <button part="button event" slide-event="join-as-speaker">
-              speaker view
+            <button part="button event" slide-event>
+              join as speaker
             </button>
 
             <hr>
@@ -33,14 +38,14 @@ class slideDeck extends HTMLElement {
               grid
             </button>
             <button part="button view" set-view>
-              presentation
+              ${slideDeck.knownViews.public}
             </button>
             <button part="button view" set-view>
-              speaker
+              ${slideDeck.knownViews.private}
             </button>
 
             <hr>
-            <button part="button" slide-event='toggle-control'>
+            <button part="button" slide-event='key-control'>
               keyboard navigation
             </button>
           </div>
@@ -231,9 +236,9 @@ class slideDeck extends HTMLElement {
     this.#setDeckID();
 
     // custom events
-    this.addEventListener('toggle-control', (e) => this.toggleAttribute('key-control'));
-    this.addEventListener('toggle-follow', (e) => this.toggleAttribute('follow-active'));
-    this.addEventListener('toggle-fullscreen', (e) => this.toggleFullScreen());
+    this.addEventListener('key-control', (e) => this.toggleKeyControl());
+    this.addEventListener('follow-active', (e) => this.toggleFollowActive());
+    this.addEventListener('full-screen', (e) => this.toggleFullScreen());
 
     this.addEventListener('join', (e) => this.join());
     this.addEventListener('start', (e) => this.start());
@@ -242,10 +247,10 @@ class slideDeck extends HTMLElement {
     this.addEventListener('blank-slide', (e) => this.blankSlide());
     this.addEventListener('join-as-speaker', (e) => this.joinAsSpeaker());
 
-    this.addEventListener('next', (e) => this.move(1));
-    this.addEventListener('saved-slide', (e) => this.goToSaved());
-    this.addEventListener('previous', (e) => this.move(-1));
+    this.addEventListener('next', (e) => this.next());
+    this.addEventListener('previous', (e) => this.previous());
     this.addEventListener('to-slide', (e) => this.goTo(e.detail));
+    this.addEventListener('to-saved', (e) => this.goToSaved());
   };
 
   connectedCallback() {
@@ -457,7 +462,7 @@ class slideDeck extends HTMLElement {
   }
 
   resume = () => {
-    this.setAttribute('slide-view', 'presentation');
+    this.setAttribute('slide-view', slideDeck.knownViews.public);
     this.join();
   }
 
@@ -467,7 +472,7 @@ class slideDeck extends HTMLElement {
   }
 
   joinAsSpeaker = () => {
-    this.setAttribute('slide-view', 'speaker');
+    this.setAttribute('slide-view', slideDeck.knownViews.private);
     this.join();
   }
 
@@ -493,6 +498,9 @@ class slideDeck extends HTMLElement {
       document.exitFullscreen();
     }
   }
+
+  toggleKeyControl = () => this.toggleAttribute('key-control');
+  toggleFollowActive = () => this.toggleAttribute('follow-active');
 
   // --------------------------------------------------------------------------
   // attribute-change methods
@@ -586,6 +594,9 @@ class slideDeck extends HTMLElement {
     const to = (this.#getActive() || 0) + by;
     this.goTo(to);
   };
+
+  next = () => this.move(1);
+  previous = () => this.move(-1);
 
   goToSaved = () => {
     this.goTo(this.#slideFromStore());

--- a/slots.html
+++ b/slots.html
@@ -14,8 +14,8 @@
       <dialog slot="control-panel">
         <div>
           <button set-view>grid</button>
-          <button set-view>solo</button>
-          <button set-view>script</button>
+          <button set-view>presentation</button>
+          <button set-view>speaker</button>
           <form method="dialog"><button>close</button></form>
         </div>
       </dialog>
@@ -31,7 +31,7 @@
       </div>
       <div>
         <h2>Custom blank screen</h2>
-        <button slide-event>blankSlide</button>
+        <button slide-event>blank slide</button>
       </div>
       <div>
         <a href="./index.html">Back to demo</a>

--- a/slots.html
+++ b/slots.html
@@ -14,7 +14,7 @@
       <dialog slot="control-panel">
         <div>
           <button set-view>grid</button>
-          <button set-view>presentation</button>
+          <button set-view>slideshow</button>
           <button set-view>speaker</button>
           <form method="dialog"><button>close</button></form>
         </div>


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&CHANGE_ME)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

## Description
Uncomment if you want to provide a custom description.

- Mostly renaming and simplifying methods, for consistency
- The component itself is only aware of two 'built-in' views,
  named `presentation` (used for `start` and `resume` events)
  and `speaker` (used for the `join-as-speaker` event)
- Only listen for keydown on `body`, and add/remove listener on connect/disconnect
- A lot of 'keydown' event-handler cleanup to try and achieve proper priority in different situations
  1. cmd/ctrl-k always works, open/closes control panel
  2. if the control panel is open, esc will blur and close the panel
  3. if a blank slide is open, any non-cmd/ctrl key will close it (this allows you to open the control panel while a blank slide is shown)
  4. cmd/ctrl-enter will always resume presentation (or start from the top, with shift)
  5. alt-enter will always join presentation as speaker
  6. other events are only triggered when `key-control` is enabled

I was hoping to remove all known views, and allow those to be totally defined by the page author and the stylesheets. But we have useful shortcuts to start and join-as-speaker, so it seemed like those two views need to be provided. We could allow them to be changed? Or just make sure we've chosen good names. I went back and forth a bit between `presentation` and `slideshow` for the public-facing one.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._

- try lots of key combinations in different arrangements
- try all the buttons?
