### PR TITLE
Fix a typo introduced by 7cfbbcb

### DIFF
--- a/slide-deck.js
+++ b/slide-deck.js
@@ -617,7 +617,7 @@ class slideDeck extends HTMLElement {
     }
   }
 
-        const type = event.target.getAttribute('type')?.toLowerCase();
+  #isPrivateKeydown = (event) => {
     // it's only private if the focus is somewhere else
     if (event.target === this.#body) { return; }
 


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&CHANGE_ME)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description

@jamesnw it looks like we introduced a typo in one of our previous commits - not sure how. I think this is the fix?