### PR TITLE
Track view settings in URL parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,28 @@ until we achieve a stable v1.0 release
 
 ## v0.2.0 - UNRELEASED
 
-- 💥 BREAKING: The component itself is only aware of two 'built-in' views,
-  named `slideshow` (used for `start` and `resume` events)
-  and `speaker` (used for the `join-as-speaker` event)
+- 🚀 NEW: All attributes have associated getters and setters:
+  - `key-control` -> `keyControl` (boolean)
+  - `follow-active` -> `followActive` (boolean)
+  - `full-screen` -> `fullScreen` (boolean)
+  - `slide-view` -> `slideView` (string)
+- 🚀 NEW: Use the `?slide-view=viewName` query parameter
+  to create links to specific slide views.
+  When present on load, the query parameter will override
+  the session storage as well as any hardcoded attribute value.
+- 💥 BREAKING: The `slideView` property setter
+  should be used for changing views,
+  rather than manipulating the `slide-view` attribute directly.
+  This will also update session storage and the url query parameter.
+- 💥 BREAKING: When the `start` and `resume` events are fired,
+  the slide-deck is put into a `publicView`
+  (the default is `slideshow`).
+  When the `join-as-speaker` event is fired,
+  the slide-deck is put into a `privateView`
+  (the default is `speaker`).
+  These can be changed by setting the
+  `publicView` and `privateView` properties with JS,
+  or by setting the `public-view` and `private-view` attributes in HTML.
 - 💥 BREAKING: Renamed the custom event handlers and matching public methods:
   - `reset` = `reset()`
   - `join` = `join()`
@@ -26,6 +45,8 @@ until we achieve a stable v1.0 release
   - `follow-active` = `toggleFollowActive()`
 - 🐞 FIXED: Keyboard events are given proper priority, so that
   (for example) you can open the control panel from a blank slide
+- 👀 INTERNAL: Renamed static `storageKeys` to `storeValues`,
+  and static `controlKeys` to `navKeys` for clarity.
 
 ## v0.1.4 - 2024-02-28
 

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -240,7 +240,7 @@ class slideDeck extends HTMLElement {
     const params = this.urlParams;
     Object.keys(update).forEach((name) => { params.set(name, update[name]) });
     window.location.search = params;
-  }
+    window.location.search = params.toString();
 
   // views
   get publicView() {

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -235,7 +235,8 @@ class slideDeck extends HTMLElement {
     return new URLSearchParams(window.location.search);
   }
 
-  set urlParams(update) {
+  // update individual parameters
+  updateUrlParams(update) {
     const params = this.urlParams;
     Object.keys(update).forEach((name) => { params.set(name, update[name]) });
     window.location.search = params;
@@ -266,7 +267,7 @@ class slideDeck extends HTMLElement {
   }
 
   set slideView(view) {
-    this.urlParams = {'slide-view': view};
+    this.updateUrlParams({'slide-view': view});
     this.setAttribute('slide-view', view);
     sessionStorage.setItem(this.#store.view, view);
   }

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -239,8 +239,8 @@ class slideDeck extends HTMLElement {
   updateUrlParams(update) {
     const params = this.urlParams;
     Object.keys(update).forEach((name) => { params.set(name, update[name]) });
-    window.location.search = params;
     window.location.search = params.toString();
+  }
 
   // views
   get publicView() {

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -143,27 +143,14 @@ class slideDeck extends HTMLElement {
     'slide-view',
   ];
 
-  get keyControl(){
-    return this.hasAttribute('key-control');
-  }
-  get followActive(){
-    return this.hasAttribute('follow-active');
-  }
-  get fullScreen(){
-    return this.hasAttribute('full-screen');
-  }
-  get slideView(){
-    return this.getAttribute('slide-view');
-  }
-
-  static storageKeys = [
+  static storeValues = [
     'control',
     'follow',
     'view',
     'slide',
   ];
 
-  static controlKeys = {
+  static navKeys = {
     'Home': 'firstSlide',
     'End': 'lastSlide',
 
@@ -191,16 +178,98 @@ class slideDeck extends HTMLElement {
   // --------------------------------------------------------------------------
   // dynamic properties
 
-  #store = {};
   slides;
   slideCount;
   activeSlide;
+
   #controlPanel;
   #blankSlide;
   #eventButtons;
   #viewButtons;
   #goToButtons;
   #body;
+  #store = {};
+
+  // --------------------------------------------------------------------------
+  // get 'n set
+
+  // attrs
+  get keyControl() {
+    return this.hasAttribute('key-control');
+  }
+
+  set keyControl(on) {
+    if (on) {
+      this.setAttribute('key-control', '');
+    } else {
+      this.removeAttribute('key-control');
+    }
+  }
+
+  get followActive() {
+    return this.hasAttribute('follow-active');
+  }
+
+  set followActive(on) {
+    if (on) {
+      this.setAttribute('follow-active', '');
+    } else {
+      this.removeAttribute('follow-active');
+    }
+  }
+
+  get fullScreen() {
+    return this.hasAttribute('full-screen');
+  }
+
+  set fullScreen(on) {
+    if (on) {
+      this.setAttribute('full-screen', '');
+    } else {
+      this.removeAttribute('full-screen');
+    }
+  }
+
+  // params
+  get urlParams() {
+    return new URLSearchParams(window.location.search);
+  }
+
+  set urlParams(update) {
+    const params = this.urlParams;
+    Object.keys(update).forEach((name) => { params.set(name, update[name]) });
+    window.location.search = params;
+  }
+
+  // views
+  get publicView() {
+    return this.getAttribute('public-view') || slideDeck.knownViews.public;
+  }
+
+  set publicView(string) {
+    this.setAttribute('public-view', string);
+  }
+
+  get privateView() {
+    return this.getAttribute('private-view') || slideDeck.knownViews.private;
+  }
+
+  set privateView(string) {
+    this.setAttribute('private-view', string);
+  }
+
+  get slideView() {
+    return this.urlParams.get('slide-view')
+      || sessionStorage.getItem(this.#store.view)
+      || this.getAttribute('slide-view')
+      || this.publicView;
+  }
+
+  set slideView(view) {
+    this.urlParams = {'slide-view': view};
+    this.setAttribute('slide-view', view);
+    sessionStorage.setItem(this.#store.view, view);
+  }
 
   // --------------------------------------------------------------------------
   // callbacks
@@ -299,7 +368,7 @@ class slideDeck extends HTMLElement {
     this.id = this.id || this.#newDeckId();
 
     // storage keys based on slide ID
-    slideDeck.storageKeys.forEach((key) => {
+    slideDeck.storeValues.forEach((key) => {
       this.#store[key] = `${this.id}.${key}`;
     });
   }
@@ -336,12 +405,7 @@ class slideDeck extends HTMLElement {
 
   #defaultAttrs = () => {
     // view required
-    this.setAttribute(
-      'slide-view',
-      sessionStorage.getItem(this.#store.view)
-        || this.slideView
-        || slideDeck.knownViews.public
-    );
+    this.setAttribute('slide-view', this.slideView);
 
     // fullscreen must be set by user interaction
     this.removeAttribute('full-screen');
@@ -407,7 +471,7 @@ class slideDeck extends HTMLElement {
 
     this.#viewButtons.forEach((btn) => {
       btn.addEventListener('click', (e) => {
-        this.setAttribute('slide-view', this.#getButtonValue(btn, 'set-view'));
+        this.slideView = this.#getButtonValue(btn, 'set-view');
       });
       this.#setButtonToggleState(btn, 'set-view', this.slideView);
     });
@@ -457,12 +521,12 @@ class slideDeck extends HTMLElement {
   }
 
   join = () => {
-    this.setAttribute('key-control', '');
-    this.setAttribute('follow-active', '');
+    this.keyControl = true;
+    this.followActive = true;
   }
 
   resume = () => {
-    this.setAttribute('slide-view', slideDeck.knownViews.public);
+    this.slideView = this.publicView;
     this.join();
   }
 
@@ -472,7 +536,7 @@ class slideDeck extends HTMLElement {
   }
 
   joinAsSpeaker = () => {
-    this.setAttribute('slide-view', slideDeck.knownViews.private);
+    this.slideView = this.privateView;
     this.join();
   }
 
@@ -506,9 +570,8 @@ class slideDeck extends HTMLElement {
   }
 
   #onViewChange = () => {
-    this.#updateViewButtons();
     this.scrollToActive();
-    sessionStorage.setItem(this.#store.view, this.slideView);
+    this.#updateViewButtons();
   }
 
   #onKeyControlChange = () => {
@@ -698,7 +761,7 @@ class slideDeck extends HTMLElement {
     if (this.keyControl) {
       if (this.#isPrivateKeydown(event)) { return; }
 
-      switch (slideDeck.controlKeys[event.key]) {
+      switch (slideDeck.navKeys[event.key]) {
         case 'firstSlide':
           event.preventDefault();
           this.toSlide(1);


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&snake)

## Related Issue(s)

- Fixes #34

## Steps to test/reproduce

I decided to keep the attribute as the 'source of truth', since the actual styles are based on an attribute selector. Currently:

- When accessing the `slideView` property, the query parameter takes precedence, then the sessionStorage, then the attribute, and finally the default (or specified) `publicView`.
- On-load we check the `slideView`, and update the attribute to match. 
- When the `slideView` is explicitly set (which is what the view buttons do), we update all three (parameter, sessionStorage, and attr).

That means it's possible for them to get out of sync if changed directly without the setter, which I think is ok? I don't think we need to watch for changes on any of them to update the others?