### PR TITLE
Provide a slide-deck webc component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ until we achieve a stable v1.0 release
 
 ## v0.2.0 - UNRELEASED
 
+- 🚀 NEW: Provide a `slide-deck.webc` component.
 - 🚀 NEW: All attributes have associated getters and setters:
   - `key-control` -> `keyControl` (boolean)
   - `follow-active` -> `followActive` (boolean)

--- a/slide-deck.webc
+++ b/slide-deck.webc
@@ -1,0 +1,1 @@
+<script src="./slide-deck.js"></script>


### PR DESCRIPTION
## Description

A webc component that points to the slide-deck JS, for easy use as a component in 11ty projects.

## Steps to test/reproduce

- Create a PR on the css-workshop repo to use this instead of pointing a component at the node-modules folder?
