### PR TITLE
Navigation shortcuts inactive when modifier keys are pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,9 @@ until we achieve a stable v1.0 release
   - `key-control` = `toggleKeyControl()`
   - `follow-active` = `toggleFollowActive()`
 - 🐞 FIXED: Keyboard events are given proper priority, so that
-  (for example) you can open the control panel from a blank slide
+  (for example) you can open the control panel from a blank slide.
+- 🐞 FIXED: Navigation shortcuts aren't invoked
+  when a modifier key is being pressed.
 - 👀 INTERNAL: Renamed static `storageKeys` to `storeValues`,
   and static `controlKeys` to `navKeys` for clarity.
 

--- a/slide-deck.js
+++ b/slide-deck.js
@@ -702,6 +702,15 @@ class slideDeck extends HTMLElement {
   // Detect Ctrl / Cmd modifiers in a platform-agnostic way
   #cmdOrCtrl = (event) => event.ctrlKey || event.metaKey;
 
+  #isModified = (event) => this.#cmdOrCtrl(event)
+    || event.getModifierState("Shift")
+    || event.getModifierState("Alt")
+    || event.getModifierState("Meta")
+    || event.getModifierState("Fn")
+    || event.getModifierState("Hyper")
+    || event.getModifierState("OS")
+    || event.getModifierState("Super");
+
   #escToBlur = (event) => {
     if (event.key === 'Escape') {
       event.preventDefault();
@@ -790,6 +799,9 @@ class slideDeck extends HTMLElement {
 
       return;
     }
+
+    // don't continue if modifiers are pressed
+    if (this.#isModified(event)) return;
 
     // only while key-control is active
     if (this.keyControl) {


### PR DESCRIPTION
## Description

I was annoyed that any other browser shortcut involving navigation keys (arrows etc) would get hijacked for navigation. I'm not sure if this is the right way to check, but it seems to work. 

## Steps to test/reproduce

- Try navigating with arrow keys (it should navigate slides)
- Hold shift or alt or any other modifier, then an arrow key (it should do whatever the default behavior is)